### PR TITLE
Fix problem with missing template.

### DIFF
--- a/school/settings.py
+++ b/school/settings.py
@@ -125,3 +125,5 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static")
 ]
+
+CRISPY_TEMPLATE_PACK = 'bootstrap3'


### PR DESCRIPTION
crispy-forms requires a template pack to be configured.

see: http://django-crispy-forms.readthedocs.io/en/latest/install.html#template-packs